### PR TITLE
Fix error codes on shutdown

### DIFF
--- a/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
+++ b/joint_state_publisher/joint_state_publisher/joint_state_publisher.py
@@ -571,9 +571,9 @@ def main():
         rclpy.spin(jsp)
     except KeyboardInterrupt:
         pass
-
-    jsp.destroy_node()
-    rclpy.try_shutdown()
+    finally:
+        jsp.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We're getting a lot of flaky integration tests related to this node when we shut down, especially when running at high update rates. This seems to resolve it.